### PR TITLE
BigInt usage, limitations, and operations in JavaScript

### DIFF
--- a/script.js
+++ b/script.js
@@ -375,6 +375,7 @@ labelBalance.addEventListener('click', function () {
 });
 */
 
+/*
 // 184. Numeric Separators
 
 const diameter = 287_460_000_000;
@@ -391,3 +392,41 @@ console.log(PI);
 
 console.log(Number('230_000')); // NaN
 console.log(parseInt('230_000')); // 230
+*/
+
+// 185. Working with BigInt
+
+console.log(2 ** 53 - 1); // The biggest number that JavaScript can safely represent
+console.log(Number.MAX_SAFE_INTEGER);
+console.log(2 ** 53 + 1);
+console.log(2 ** 53 + 2);
+console.log(2 ** 53 + 3);
+console.log(2 ** 53 + 4);
+
+console.log(7473097234072034709237750974029569084236592n);
+console.log(BigInt(74730972));
+
+// Operations
+console.log(10000n + 10000n);
+console.log(
+  357347537458738947589347589734894573894n *
+    98237482376486235874872354872356487n
+);
+// console.log(Math.sqrt(16n)); // Error
+
+const huge = 26982374589789472390847n;
+const num = 23;
+console.log(huge + BigInt(num));
+
+// Exeptions
+console.log(20n > 15); // true
+console.log(20n === 20); // false
+console.log(typeof 20n); // bigint
+console.log(20n === 20); // false
+console.log(20n == 20); // true
+
+console.log(huge + ' is REALLY big!!!');
+
+// Divisions
+console.log(11n / 3n);
+console.log(10 / 3);


### PR DESCRIPTION
##  PR: Working with BigInt in JavaScript (Section 185)

This PR introduces the `BigInt` primitive type, used for representing integers larger than `Number.MAX_SAFE_INTEGER` safely, and practices how to operate with it.

---

### ✅ What's Practiced

1. **Safe Integer Limits**
   - Logged the largest safe integer using:
     ```js
     console.log(2 ** 53 - 1);
     console.log(Number.MAX_SAFE_INTEGER);
     ```

2. **Creating BigInt Values**
   - Using BigInt literals with `n` suffix:
     ```js
     const large = 7473097234072034709237750974029569084236592n;
     ```
   - Using the `BigInt()` constructor:
     ```js
     const small = BigInt(74730972);
     ```

3. **BigInt Arithmetic**
   - Addition and multiplication with BigInt:
     ```js
     console.log(10000n + 10000n);
     console.log(BigInt(23) * huge);
     ```

4. **Type Mixing & Errors**
   - ❌ Mixed operations like `BigInt + Number` throw a TypeError.
   - ✅ Must explicitly convert:
     ```js
     console.log(huge + BigInt(23));
     ```

5. **Comparisons**
   - `==` works (loose equality), but `===` does not:
     ```js
     console.log(20n == 20);  // true
     console.log(20n === 20); // false
     ```

6. **Other Use Cases**
   - `typeof 20n` → `'bigint'`
   - `BigInt + string` → automatic string concatenation

7. **Unsupported Operations**
   - ❌ `Math.sqrt(16n)` → throws error
   - ❌ Decimal division is truncated:
     ```js
     console.log(11n / 3n); // 3n (truncated)
     ```

---

### 🧠 Key Takeaways

- Use `BigInt` for database IDs, crypto, or when dealing with backend data that exceeds JavaScript's safe range.
- Avoid mixing regular numbers and BigInts—explicit conversion is required.
- Math functions and floating-point operations do **not** support BigInt.


