### PR TITLE
Internationalized number and currency formatting using Intl.NumberF…

### DIFF
--- a/script.js
+++ b/script.js
@@ -108,6 +108,13 @@ const formatMovementDate = function (date, locale) {
   }
 };
 
+const formatCur = function (value, locale, currency) {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: currency,
+  }).format(value);
+};
+
 const displayMovements = function (acc, sort = false) {
   containerMovements.innerHTML = '';
 
@@ -124,6 +131,8 @@ const displayMovements = function (acc, sort = false) {
     const date = new Date(movementDate);
     const displayDate = formatMovementDate(date, acc.locale);
 
+    const formattedMov = formatCur(movement, acc.locale, acc.currency);
+
     const html = `
       <div class="movements__row">
         <div class="movements__type movements__type--${type}">${
@@ -131,7 +140,7 @@ const displayMovements = function (acc, sort = false) {
     } ${type}</div>
         <div class="movements__date">${displayDate}</div>
        
-        <div class="movements__value">${movement.toFixed(2)}€</div>
+        <div class="movements__value">${formattedMov}</div>
       </div>
     `;
 
@@ -142,19 +151,21 @@ const displayMovements = function (acc, sort = false) {
 
 const calcDisplayBalance = function (acc) {
   acc.balance = acc.movements.reduce((acc, mov) => acc + mov, 0);
-  labelBalance.textContent = `${acc.balance.toFixed(2)}€`;
+
+  labelBalance.textContent = formatCur(acc.balance, acc.locale, acc.currency);
 };
 
 const calcDisplaySummary = function (acc) {
   const incomes = acc.movements
     .filter(mov => mov > 0)
     .reduce((acc, mov) => acc + mov, 0);
-  labelSumIn.textContent = `${incomes.toFixed(2)}€`;
+
+  labelSumIn.textContent = formatCur(incomes, acc.locale, acc.currency);
 
   const out = acc.movements
     .filter(mov => mov < 0)
     .reduce((acc, mov) => acc + mov, 0);
-  labelSumOut.textContent = `${Math.abs(out).toFixed(2)}€`;
+  labelSumOut.textContent = formatCur(out, acc.locale, acc.currency);
 
   const interest = acc.movements
     .filter(mov => mov > 0)
@@ -164,7 +175,7 @@ const calcDisplaySummary = function (acc) {
       return int >= 1;
     })
     .reduce((acc, int) => acc + int, 0);
-  labelSumInterest.textContent = `${interest.toFixed(2)}€`;
+  labelSumInterest.textContent = formatCur(interest, acc.locale, acc.currency);
 };
 
 const createUsernames = function (accs) {
@@ -555,3 +566,29 @@ console.log(future);
 // const days1 = calcDaysPassed(new Date(2037, 3, 4), new Date(2037, 3, 14));
 
 // console.log(days1);
+
+// 191. Internationalizing Numbers (Intl)
+
+const num = 3884764.23;
+
+// check in MDN for more options
+const options = {
+  style: 'currency',
+  unit: 'celsius',
+  currency: 'EUR',
+  // useGrouping: false,
+};
+
+console.log(
+  'US:         ',
+  new Intl.NumberFormat('en-US', options).format(num)
+);
+console.log(
+  'Germany:    ',
+  new Intl.NumberFormat('de-DE', options).format(num)
+);
+console.log('Syria:    ', new Intl.NumberFormat('ar-SY', options).format(num));
+console.log(
+  navigator.language,
+  new Intl.NumberFormat(navigator.language, options).format(num)
+);


### PR DESCRIPTION
##  PR: Internationalizing Numbers (Intl) – Section 191

This PR completes the internationalization layer for number formatting in the Bankist app using `Intl.NumberFormat`.

---

### ✅ What’s Implemented

- 🌍 **Reusable Formatting Utility**
  - Created `formatCur(value, locale, currency)` to format any number with locale-aware currency.
  - Avoids hardcoded currency symbols or manual formatting.

- 📈 **Applied to Key UI Areas**
  - All transaction values (`movements`)
  - Current account balance
  - Summary sections (In, Out, Interest)

- 🔁 **Dynamic Currency Handling**
  - Uses `acc.locale` and `acc.currency` dynamically per account.
  - Ensures each user sees values properly formatted in their language and currency (e.g., `en-US` with `USD`, `pt-PT` with `EUR`).

---

### 🛠 Notes

- Builds on top of Section 190 (Date Intl).
- Next PR may introduce localization for error messages or form validation.

---

### 📸 Preview

| User             | Locale     | Currency | Example Format      |
|------------------|------------|----------|----------------------|
| User1 | `pt-PT`    | `EUR`    | `1 300,00 €`         |
| User2     | `en-US`    | `USD`    | `$1,300.00`          |

